### PR TITLE
feature: add idempotency key to Pub/Sub message

### DIFF
--- a/modules/google-pubsub/package.json
+++ b/modules/google-pubsub/package.json
@@ -25,7 +25,8 @@
   "dependencies": {
     "@google-cloud/pubsub": "0.22.0",
     "message-crypto": "1.0.0",
-    "object-hash": "1.3.1"
+    "object-hash": "1.3.1",
+    "uuid": "3.3.2"
   },
   "devDependencies": {
     "@nestjs/common": "5.4.1",

--- a/modules/google-pubsub/src/pubsub.service.test.ts
+++ b/modules/google-pubsub/src/pubsub.service.test.ts
@@ -49,9 +49,16 @@ describe('pubsub service', async () => {
     });
 
     test('should call the publish method on the underlying pub-sub library', async (): Promise<void> => {
-        await expect(service.publishMessage('slack', 'mockmsg')).resolves.toBeUndefined();
+        const idempotencyKeyMatch: string = '__' + new Date().toISOString().substring(0, 10);
+        await expect(service.publishMessage('slack', 'mockmsg'))
+            .resolves
+            .toContain(idempotencyKeyMatch);
+
         // tslint:disable-next-line
-        expect(mockPublish).toBeCalledWith(expect.any(Buffer), {signature: expect.anything()});
+        expect(mockPublish).toBeCalledWith(
+            expect.any(Buffer),
+            {idempotencyKey: expect.stringContaining(idempotencyKeyMatch), signature: expect.anything()},
+        );
         expect(pubsubHelper.prepareForPubsub).toBeCalledWith('slack', 'mockmsg', 'userAgent');
     });
 });


### PR DESCRIPTION
Idempotency key is added to attributes and also returned by `publishMessage`.