### PR TITLE
bug: fix wrong usage of rxjs of method

### DIFF
--- a/modules/common/src/bugsnag/bugsnag-ignore-exceptions.decorator.ts
+++ b/modules/common/src/bugsnag/bugsnag-ignore-exceptions.decorator.ts
@@ -30,7 +30,7 @@ export class BugsnagIgnoreExceptionsInterceptor implements NestInterceptor {
                         const response: any = context.switchToHttp().getResponse();
                         response.status(error.status || 500).json({err: error.response ? error.response.message : undefined});
 
-                        return of();
+                        return of(undefined);
                     }
                     // rethrow
                     throw error;


### PR DESCRIPTION
This change is related to an issue found on top of this PR: https://github.com/erento/category/pull/72

I found out that using `of()` from RxJS without a parameter leads to `EmptyError` with a message `no elements in sequence` (see attached image). To overcome this, we always need to pass an argument, either undefined or null for observable to be emitted (or, of course, with some other value).

<img width="1215" alt="Snímek obrazovky 2022-03-25 v 10 56 29" src="https://user-images.githubusercontent.com/156132/160098468-9d696398-3d43-4f6f-a0f2-152fb67519e0.png">
