### PR TITLE
feature: DEV-6756 update common module to report and silence errors of all types

### DIFF
--- a/modules/common/package-lock.json
+++ b/modules/common/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@erento/nestjs-common",
-      "version": "5.5.0",
+      "version": "6.0.0",
       "license": "MIT",
       "dependencies": {
         "@google-cloud/profiler": "5.0.3",

--- a/modules/common/src/bugsnag/bugsnag-ignore-exceptions.decorator.ts
+++ b/modules/common/src/bugsnag/bugsnag-ignore-exceptions.decorator.ts
@@ -1,8 +1,8 @@
 import {applyDecorators, SetMetadata} from '@nestjs/common';
-import {SILENT_FAIL_TOKEN} from '../guards/consts';
+import {bugsnagIgnoredExceptions} from './consts';
 
 export function BugsnagIgnoreExceptions (exceptions: any[]): MethodDecorator {
     return applyDecorators(
-        SetMetadata(SILENT_FAIL_TOKEN, exceptions),
+        SetMetadata(bugsnagIgnoredExceptions, exceptions),
     );
 }

--- a/modules/common/src/bugsnag/bugsnag-ignore-exceptions.interceptor.ts
+++ b/modules/common/src/bugsnag/bugsnag-ignore-exceptions.interceptor.ts
@@ -1,0 +1,36 @@
+import {CallHandler, ExecutionContext, Injectable, NestInterceptor} from '@nestjs/common';
+import {Reflector} from '@nestjs/core';
+import {Observable, of} from 'rxjs';
+import {catchError} from 'rxjs/operators';
+import {bugsnagIgnoredExceptions} from './consts';
+
+@Injectable()
+export class BugsnagIgnoreExceptionsInterceptor implements NestInterceptor {
+    constructor (private readonly reflector: Reflector) {}
+
+    public intercept (context: ExecutionContext, next: CallHandler): Observable<any> | Promise<Observable<any>> {
+        const exceptions: any[] | undefined = this.reflector.get<any[]>(bugsnagIgnoredExceptions, context.getHandler());
+        if (!exceptions) {
+            return next.handle();
+        }
+
+        return next
+            .handle()
+            .pipe(
+                catchError((error: any): Observable<any> => {
+                    if (exceptions.some((e: any): boolean => error instanceof e)) {
+                        // return error as result to avoid errors being caught by Bugsnag
+                        const response: any = context.switchToHttp()
+                            .getResponse();
+
+                        response.status(error.status || 500)
+                            .json({err: error.response ? error.response.message : undefined});
+
+                        return of(undefined);
+                    }
+                    // rethrow
+                    throw error;
+                }),
+            );
+    }
+}

--- a/modules/common/src/bugsnag/bugsnag.filter.ts
+++ b/modules/common/src/bugsnag/bugsnag.filter.ts
@@ -20,9 +20,9 @@ export class BugsnagErrorFilter implements ExceptionFilter {
         const status: number = err instanceof HttpException ? err.getStatus() : HttpStatus.INTERNAL_SERVER_ERROR;
         const exception: Error = err instanceof Error ? err : new Error(err);
 
-        (this.loggerMethod || console.error)(exception);
-
         if (!err?.silent) {
+            (this.loggerMethod || console.error)(exception);
+
             this.bugsnagClient.notifyWithMetadata(
                 exception,
                 {

--- a/modules/common/src/bugsnag/consts/index.ts
+++ b/modules/common/src/bugsnag/consts/index.ts
@@ -1,0 +1,1 @@
+export const bugsnagIgnoredExceptions: string = 'bugsnag-ignored-exceptions';

--- a/modules/common/src/exceptions/silent-unauthorized.exception.ts
+++ b/modules/common/src/exceptions/silent-unauthorized.exception.ts
@@ -1,0 +1,7 @@
+import {UnauthorizedException} from './unauthorized.exception';
+
+export class SilentUnauthorizedException extends UnauthorizedException {
+    constructor (objectOrError?: string | object | any, description?: string, silent: boolean = true) {
+        super(objectOrError, description, silent);
+    }
+}

--- a/modules/common/src/exceptions/unauthorized.exception.ts
+++ b/modules/common/src/exceptions/unauthorized.exception.ts
@@ -1,7 +1,8 @@
-import {UnauthorizedException} from '@nestjs/common';
+import {UnauthorizedException as NestJsUnauthorizedException} from '@nestjs/common';
 
-export class CommonUnauthorizedException extends UnauthorizedException {
+export class UnauthorizedException extends NestJsUnauthorizedException {
     public silent: boolean = false;
+
     constructor (objectOrError?: string | object | any, description?: string, silent?: boolean) {
         super(objectOrError, description);
         this.silent = !!silent;

--- a/modules/common/src/guards/authorization.decorator.ts
+++ b/modules/common/src/guards/authorization.decorator.ts
@@ -1,7 +1,12 @@
 import {CustomDecorator, SetMetadata} from '@nestjs/common';
 import {TOKEN} from './consts';
+import {AuthMetadata, AuthOptions, AuthTokenValue} from './interfaces';
 
 // tslint:disable-next-line variable-name
-export const Auth: (tokenValue?: string | string[]) => CustomDecorator = (
-    tokenValue: string | string[] | undefined = undefined,
-): CustomDecorator => SetMetadata(TOKEN, tokenValue);
+export const Auth: (tokenValue: AuthTokenValue, options?: AuthOptions) => CustomDecorator = (
+    tokenValue: AuthTokenValue = undefined,
+    options?: AuthOptions,
+): CustomDecorator => SetMetadata(TOKEN, <AuthMetadata> {tokenValue, options: {
+    silent: false,
+    ...options,
+}});

--- a/modules/common/src/guards/authorization.guard.test.ts
+++ b/modules/common/src/guards/authorization.guard.test.ts
@@ -1,5 +1,8 @@
 import {ExecutionContext} from '@nestjs/common';
+import {SilentUnauthorizedException} from '../exceptions/silent-unauthorized.exception';
+import {UnauthorizedException} from '../exceptions/unauthorized.exception';
 import {AuthorizationGuard} from './authorization.guard';
+import {AuthMetadata} from './interfaces';
 
 const getExecutionContext: (req: any) => ExecutionContext = (req: any): ExecutionContext => <any> {
     switchToHttp: (): any => {
@@ -9,9 +12,23 @@ const getExecutionContext: (req: any) => ExecutionContext = (req: any): Executio
 };
 
 describe('Authorization Guard', (): void => {
+    it('Should pass when Auth decorator is not used at all', (): void => {
+        const reflector: any = jest.fn()
+            .mockReturnValueOnce(undefined);
+        const req: Request = <any> {
+            headers: {},
+        };
+        expect(new AuthorizationGuard(<any> {get: reflector})
+            .canActivate(getExecutionContext(req)))
+            .toBe(true);
+    });
+
     it('Should authorize when token is not passed', (): void => {
-        const reflector: any = jest.fn();
-        reflector.mockReturnValueOnce(undefined);
+        const reflector: any = jest.fn()
+            .mockReturnValueOnce(<AuthMetadata> {
+                tokenValue: undefined,
+                options: {silent: false},
+            });
         const req: Request = <any> {
             headers: {},
         };
@@ -26,8 +43,11 @@ describe('Authorization Guard', (): void => {
                 'x-token-role': 'service',
             },
         };
-        const reflector: any = jest.fn();
-        reflector.mockReturnValueOnce('service');
+        const reflector: any = jest.fn()
+            .mockReturnValueOnce(<AuthMetadata> {
+                tokenValue: 'service',
+                options: {silent: false},
+            });
         expect(new AuthorizationGuard(<any> {get: reflector})
             .canActivate(getExecutionContext(req)))
             .toBe(true);
@@ -39,8 +59,11 @@ describe('Authorization Guard', (): void => {
                 'x-token-role': 'service',
             },
         };
-        const reflector: any = jest.fn();
-        reflector.mockReturnValueOnce(['x', 'y', 'service', 'z']);
+        const reflector: any = jest.fn()
+            .mockReturnValueOnce(<AuthMetadata> {
+                tokenValue: ['x', 'y', 'service', 'z'],
+                options: {silent: false},
+            });
         expect(new AuthorizationGuard(<any> {get: reflector})
             .canActivate(getExecutionContext(req)))
             .toBe(true);
@@ -53,7 +76,10 @@ describe('Authorization Guard', (): void => {
             },
         };
         const reflector: any = jest.fn()
-            .mockReturnValueOnce(undefined);
+            .mockReturnValueOnce(<AuthMetadata> {
+                tokenValue: undefined,
+                options: {silent: false},
+            });
         expect(new AuthorizationGuard(<any> {get: reflector})
             .canActivate(getExecutionContext(req)))
             .toBe(true);
@@ -65,8 +91,11 @@ describe('Authorization Guard', (): void => {
                 'x-token-role': 'service',
             },
         };
-        const reflector: any = jest.fn();
-        reflector.mockReturnValueOnce('not matching');
+        const reflector: any = jest.fn()
+            .mockReturnValueOnce(<AuthMetadata> {
+                tokenValue: 'not matching',
+                options: {silent: false},
+            });
         expect((): boolean => new AuthorizationGuard(<any> {get: reflector})
             .canActivate(getExecutionContext(req)))
             .toThrowErrorMatchingSnapshot();
@@ -78,8 +107,11 @@ describe('Authorization Guard', (): void => {
                 'x-token-role': 'service',
             },
         };
-        const reflector: any = jest.fn();
-        reflector.mockReturnValueOnce(['not matching', 'not-matching-2']);
+        const reflector: any = jest.fn()
+            .mockReturnValueOnce(<AuthMetadata> {
+                tokenValue: ['not matching', 'not-matching-2'],
+                options: {silent: false},
+            });
         expect((): boolean => new AuthorizationGuard(<any> {get: reflector})
             .canActivate(getExecutionContext(req)))
             .toThrowErrorMatchingSnapshot();
@@ -89,10 +121,45 @@ describe('Authorization Guard', (): void => {
         const req: Request = <any> {
             headers: {},
         };
-        const reflector: any = jest.fn();
-        reflector.mockReturnValueOnce('not matching');
+        const reflector: any = jest.fn()
+            .mockReturnValueOnce(<AuthMetadata> {
+                tokenValue: 'not matching',
+                options: {silent: false},
+            });
         expect((): boolean => new AuthorizationGuard(<any> {get: reflector})
             .canActivate(getExecutionContext(req)))
             .toThrowErrorMatchingSnapshot();
+    });
+
+    it('Should throw laud exception', (): void => {
+        const req: Request = <any> {
+            headers: {
+                'x-token-role': 'service',
+            },
+        };
+        const reflector: any = jest.fn()
+            .mockReturnValueOnce(<AuthMetadata> {
+                tokenValue: 'not matching',
+                options: {silent: false},
+            });
+        expect((): boolean => new AuthorizationGuard(<any> {get: reflector})
+            .canActivate(getExecutionContext(req)))
+            .toThrowError(UnauthorizedException);
+    });
+
+    it('Should throw silent exception', (): void => {
+        const req: Request = <any> {
+            headers: {
+                'x-token-role': 'service',
+            },
+        };
+        const reflector: any = jest.fn()
+            .mockReturnValueOnce(<AuthMetadata> {
+                tokenValue: 'not matching',
+                options: {silent: true},
+            });
+        expect((): boolean => new AuthorizationGuard(<any> {get: reflector})
+            .canActivate(getExecutionContext(req)))
+            .toThrowError(SilentUnauthorizedException);
     });
 });

--- a/modules/common/src/guards/consts/index.ts
+++ b/modules/common/src/guards/consts/index.ts
@@ -1,4 +1,3 @@
 export const TOKEN: string = 'authToken';
 export const TOKEN_ROLE_HEADER: string = 'x-token-role';
 export const TOKEN_USER_ID_HEADER: string = 'x-token-userid';
-export const SILENT_FAIL_TOKEN: string = 'silent-fail-token';

--- a/modules/common/src/guards/interfaces/index.ts
+++ b/modules/common/src/guards/interfaces/index.ts
@@ -4,3 +4,14 @@ export enum AuthorizationType {
     admin = 'admin',
     seller = 'seller',
 }
+
+export interface AuthOptions {
+    silent: boolean;
+}
+
+export type AuthTokenValue = string | string[] | undefined;
+
+export interface AuthMetadata {
+    tokenValue: AuthTokenValue;
+    options: AuthOptions;
+}

--- a/modules/common/src/init.ts
+++ b/modules/common/src/init.ts
@@ -12,11 +12,12 @@ const gcpMonitoringContext: Config = {
 };
 
 export function onApplicationInit (): void {
-    traceStart(gcpMonitoringContext);
-    profilerStart(gcpMonitoringContext)
-        .then((): void => {
-            console.log('profiler started');
-        });
-
+    if (!Environments.isDev()) {
+        traceStart(gcpMonitoringContext);
+        profilerStart(gcpMonitoringContext)
+            .then((): void => {
+                console.log('profiler started');
+            });
+    }
     (<any> axios).defaults.headers.common['user-agent'] = USER_AGENT;
 }

--- a/modules/common/src/public-api.ts
+++ b/modules/common/src/public-api.ts
@@ -1,5 +1,6 @@
 export * from './bugsnag/breadcrumbs';
 export * from './bugsnag/bugsnag-ignore-exceptions.decorator';
+export * from './bugsnag/bugsnag-ignore-exceptions.interceptor';
 export * from './bugsnag/bugsnag.client';
 export * from './bugsnag/bugsnag.filter';
 export * from './bugsnag/bugsnag.module';


### PR DESCRIPTION
Breaking changes:
- Introducing back `BugsnagIgnoreExceptionsInterceptor`
- `BugsnagIgnoreExceptions` is now again taking care of all exceptions


### New behavior:
**To silence exceptions within functions body use:**
```typescript
@BugsnagIgnoreExceptions([NotFoundException])
```

**To silence exceptions within authorization guard use:**
```typescript
@Auth(AuthorizationType.seller, {silent: true})
```

**To silence `UnauthorizedException` outside of authorization guard use also `BugsnagIgnoreExceptions`:**
```typescript
    @Auth(AuthorizationType.seller, {silent: true})
    @BugsnagIgnoreExceptions([UnauthorizedException])
    public getUserCreditsAsSeller (@Headers(TOKEN_USER_ID_HEADER) userId?: string): Promise<Credit> {
        if (!userId) {
            throw new UnauthorizedException('Unauthorized');
        }
```
In this case `Auth` decorator takes exceptions silent within authorization guard and `BugsnagIgnoreExceptions` within the function's body.